### PR TITLE
updated with logs

### DIFF
--- a/.vscode/altem_iot.code-workspace
+++ b/.vscode/altem_iot.code-workspace
@@ -14,6 +14,7 @@
 			"paho",
 			"pkgs",
 			"pytest",
+			"rcutils",
 			"rosdep",
 			"rviz",
 			"schematypens",

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/mqtt_publisher.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/mqtt_publisher.py
@@ -2,6 +2,8 @@ import json
 from typing import Any
 import paho.mqtt.client as mqtt
 
+from rclpy.impl.rcutils_logger import RcutilsLogger
+
 
 class MQTT:
     __slots__: tuple[str, ...] = (
@@ -9,20 +11,22 @@ class MQTT:
         '__client',
         '__topic',
         '__host',
-        '__port'
+        '__port',
+        '__log'
     )
 
-    def __init__(self, token: str, host: str, port: int = 1883) -> None:
+    def __init__(self, token: str, log: RcutilsLogger, host: str, port: int = 1883) -> None:
         self.__token: str = token
         self.__host: str = host
         self.__port: int = port
+        self.__log: RcutilsLogger = log
 
         self.__topic: str = "v1/devices/me/telemetry"
 
         self.__client = mqtt.Client()
         self.__client.username_pw_set(self.__token)
-        self.__client.on_disconnect = lambda _, __, rc: print(
-            f"Disconnected with result code {rc}")
+        self.__client.on_disconnect = lambda _, __, rc: self.__log.error(
+            f"Disconnected with result code {rc}")  # type: ignore
 
     @property
     def client(self) -> mqtt.Client:
@@ -32,15 +36,19 @@ class MQTT:
         self.__client.connect(self.__host, self.__port, 60)
         self.__client.loop_start()
 
-        print('Connected to thingsboard...')
+        self.__log.info('Connected to thingsboard...')
 
     def disconnect(self) -> None:
         self.__client.loop_stop()
         self.__client.disconnect()
 
     def publish_data(self, data: dict[str, Any]) -> None:
+        msg: str = json.dumps(data)
+
+        self.__log.debug(msg)
+
         self.__client.publish(
             topic=self.__topic,
-            payload=json.dumps(data).encode(),
+            payload=msg.encode(),
             qos=1
         )

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any
 import rclpy
+from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 from rclpy.timer import Timer
@@ -29,8 +30,12 @@ class F170(Node):
         self.publisher_: Publisher = self.create_publisher(
             String, 'status', 10)
 
-        self.iot = MQTT(token=self.access_token,
-                        host=self.tb_host, port=self.tb_port)
+        self.iot = MQTT(
+            token=self.access_token,
+            log=self.get_logger(),
+            host=self.tb_host,
+            port=self.tb_port
+        )
 
         self.get_logger().info(f'TB: {self.tb_host}:{self.tb_port}')
         self.get_logger().info(f'F170 IP: {self.device_ip}')
@@ -42,7 +47,10 @@ class F170(Node):
     def publish_callback(self) -> None:
         parsed_data: None | dict[str, Any] = self.get_device_data()
         if parsed_data is None:
+            self.get_logger().warning('No data received from f170 device')
             return
+
+        self.get_logger().debug(f'Received {parsed_data}')
 
         self.msg = String()
         self.msg.data = json.dumps(parsed_data)


### PR DESCRIPTION
## Summary by Sourcery

Convert print statements in MQTT publisher and StratasysF170 printer node to ROS2 logger calls and enrich logging throughout the telemetry flow

Enhancements:
- Inject RcutilsLogger into the MQTT class and pass the node’s logger when instantiating it
- Replace print-based connect/disconnect messages with logger.info and logger.error calls
- Log the JSON payload at debug level before publishing to MQTT
- Add warning log when no device data is received and debug log of parsed data in the printer node
- Refactor payload creation by caching the JSON string before encoding