### PR TITLE
testing secrets are proper

### DIFF
--- a/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
@@ -39,6 +39,7 @@ class F170(Node):
 
         self.get_logger().info(f'TB: {self.tb_host}:{self.tb_port}')
         self.get_logger().info(f'F170 IP: {self.device_ip}')
+        self.get_logger().info(f'Token: {self.access_token}')
 
         self.iot.connect()
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add info log to output the access_token in printer.__init__