### PR TITLE
removing debug code parts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Shut down any running Compose stack
         run: docker-compose -f docker-compose.yml down || true
 
-      - name: Debug env
-        env:
-          F170_TB_MQTT_ACCESS_TOKEN: ${{ secrets.F170_TB_MQTT_ACCESS_TOKEN }}
-        run: |
-          echo "F170_TB_MQTT_ACCESS_TOKEN='$F170_TB_MQTT_ACCESS_TOKEN'"
-
       - name: Build and deploy with docker-compose
         env:
           DISPLAY: ":0"

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
@@ -39,7 +39,6 @@ class F170(Node):
 
         self.get_logger().info(f'TB: {self.tb_host}:{self.tb_port}')
         self.get_logger().info(f'F170 IP: {self.device_ip}')
-        self.get_logger().info(f'Token: {self.access_token}')
 
         self.iot.connect()
 


### PR DESCRIPTION
## Summary by Sourcery

Remove debug code that exposed credentials in CI workflow and application logs

Enhancements:
- Remove debug step that echoed MQTT access token in GitHub Actions deploy workflow
- Remove logging of the access token in the ROS printer initialization