### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
+version: "3.8"
+
 services:
   ros:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
+    image: bonnybk/altem_iot:latest  # <-- Change this to your image
     container_name: f170_ros
     environment:
       DISPLAY: ${DISPLAY}


### PR DESCRIPTION
## Summary by Sourcery

Update docker-compose.yml to version 3.8 and simplify the ros service configuration by using a pre-built image instead of a local build

Enhancements:
- Bump docker-compose file format to version 3.8
- Switch ros service from building locally to using a pre-built Docker image