### PR TITLE
Dev

### DIFF
--- a/.vscode/altem_iot.code-workspace
+++ b/.vscode/altem_iot.code-workspace
@@ -8,8 +8,13 @@
 		"cSpell.words": [
 			"altem",
 			"altempi",
+			"amqtt",
 			"colcon",
 			"cpus",
+			"gmqtt",
+			"httpx",
+			"iputils",
+			"keepalive",
 			"MITSHM",
 			"paho",
 			"pkgs",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --break-system-packages python-dotenv requests paho-mqtt
+RUN pip install --break-system-packages python-dotenv httpx gmqtt
 
 COPY ./ros_workspace /ros_workspace
 

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/device.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/device.py
@@ -1,15 +1,91 @@
-from requests import Response, get
-from datetime import datetime
+from asyncio.subprocess import Process
+import platform
+import asyncio
+from typing import Any, Optional
+from httpx import AsyncClient, Response
+
+import rclpy
+from rclpy.impl.rcutils_logger import RcutilsLogger
 
 
-def get_device_status(ip: str) -> str:
-    endpoint: str = f'http://{ip}:5000/current'
+class DeviceRequest:
+    __slots__: tuple[str, ...] = (
+        '_client',
+        '_base_url',
+        '_timeout',
+        '_log'
+    )
 
-    try:
-        response: Response = get(endpoint, timeout=5)
+    def __init__(self, url: str, log: RcutilsLogger, timeout: float = 10.0) -> None:
+        self._base_url: str = f'http://{url}:5000'
+        self._timeout: float = timeout
+        self._log: RcutilsLogger = log
+
+        self._client: AsyncClient
+
+    async def _is_client(self) -> bool:
+        return hasattr(self, '_client')
+
+    async def connect(self) -> None:
+        if not await self._is_client():
+            self._log.info(f'Trying to connect to {self._base_url}')
+            self._client = AsyncClient(
+                base_url=self._base_url, timeout=self._timeout)
+
+    async def disconnect(self) -> None:
+        if await self._is_client():
+            await self._client.aclose()
+
+    async def get(self, endpoint: str = '/current', params: Optional[dict[str, Any]] = None) -> Response:
+        if not await self._is_client():
+            raise RuntimeError("Client not initialized. Use 'connect'.")
+
+        response: Response = await self._client.get(endpoint, params=params)
         response.raise_for_status()
-        return response.text
+        return response
 
-    except Exception as e:
-        print(f"{datetime.now()} | Error occurred: {e}")
-        raise e
+
+async def ping_ip(ip: str, count: int = 1, timeout: int = 1) -> bool:
+    system: str = platform.system().lower()
+    args: list[str] = ["ping"]
+
+    if system == "windows":
+        args += ["-n", str(count), "-w", str(timeout * 1000), ip]
+    else:
+        args += ["-c", str(count), "-W", str(timeout), ip]
+
+    process: Process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL
+    )
+    return await process.wait() == 0
+
+
+async def wait_for_device_ip(
+        ip: str, delay: float = 2.0, max_attempts: int = 0,
+        logger: Optional[RcutilsLogger] = None) -> bool:
+
+    attempt = 0
+    while rclpy.ok():
+        if await ping_ip(ip):
+            if logger:
+                logger.info(f"Device at {ip} is reachable.")
+            return True
+
+        attempt += 1
+        msg: str = f"Device at {ip} not reachable. Attempt {attempt}"
+        if logger:
+            logger.warn(msg)
+        else:
+            print(msg)
+
+        if max_attempts and attempt >= max_attempts:
+            if logger:
+                logger.error(
+                    f"Device at {ip} not reachable after {max_attempts} attempts.")
+            return False
+
+        await asyncio.sleep(delay)
+
+    return False

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/mqtt_publisher.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/mqtt_publisher.py
@@ -1,7 +1,11 @@
+import asyncio
 import json
-from typing import Any
+from typing import Any, Optional
 import paho.mqtt.client as mqtt
+import rclpy
 from rclpy.impl.rcutils_logger import RcutilsLogger
+
+from gmqtt import Client
 
 
 class MQTT:
@@ -36,9 +40,9 @@ class MQTT:
 
     def connect(self) -> None:
         try:
+            self.__log.info('Trying to connect to ThingsBoard...')
             self.__client.connect(self.__host, self.__port, keepalive=60)
             self.__client.loop_start()
-            self.__log.info('Trying to connect to ThingsBoard...')
         except Exception as e:
             self.__log.error(f'Failed to connect: {e}')
 
@@ -72,3 +76,111 @@ class MQTT:
                 client.reconnect()
             except Exception as e:
                 self.__log.error(f'Auto-reconnect failed: {e}')
+
+
+class MQTTClient:
+    __slots__: tuple[str, ...] = (
+        '_token',
+        '_client',
+        '_topic',
+        '_host',
+        '_port',
+        '_log',
+        '_connected',
+    )
+
+    def __init__(self, token: str, log: RcutilsLogger, host: str, port: int = 1883) -> None:
+        self._token: str = token
+        self._host: str = host
+        self._port: int = port
+        self._log: RcutilsLogger = log
+
+        self._client: Client
+
+        self._topic: str = "v1/devices/me/telemetry"
+
+        self._connected = asyncio.Event()
+
+    async def _is_client(self) -> bool:
+        return hasattr(self, '_client')
+
+    async def connect(self) -> None:
+        if not await self._is_client():
+            self._log.info(f'Trying to connect to {self._host}:{self._port}')
+            self._client = Client(client_id=f'id-client-{id(self)}')
+            self._client.set_auth_credentials(self._token, None)
+
+            self._client.set_config(
+                {
+                    'reconnect_retries': 10,
+                    'reconnect_delay': 60
+                }
+            )
+
+            self._client.on_connect = self._on_connect
+            self._client.on_disconnect = self._on_disconnect
+
+            await self._client.connect(
+                self._host, self._port,
+                keepalive=60
+            )
+
+            await self._connected.wait()
+
+    async def disconnect(self) -> None:
+        if await self._is_client():
+            await self._client.disconnect()
+
+    def _on_connect(self, *_) -> None:
+        self._connected.set()
+        self._log.info('Successfully connected to ThingsBoard.')
+
+    def _on_disconnect(self, *_) -> None:
+        self._connected.clear()
+        self._log.warn("Disconnected from ThingsBoard. Reconnecting...")
+
+    async def publish_data(self, data: dict[str, Any], qos: int = 1, retain: bool = False) -> None:
+        msg: str = json.dumps(data)
+
+        if not self._connected.is_set():
+            raise RuntimeError("Client not initialized. Use 'connect'.")
+
+        self._log.info(
+            f'Publishing data [topic: {self._topic}, {self._host}:{self._port}]')
+
+        self._client.publish(self._topic, msg, qos, retain)
+
+
+async def wait_for_broker(
+        host: str, port: int = 1883,
+        delay: float = 2.0, max_attempts: int = 0,
+        logger: Optional[RcutilsLogger] = None) -> bool:
+
+    attempt = 0
+    while rclpy.ok():
+        try:
+            _, writer = await asyncio.open_connection(host, port)
+            writer.close()
+            await writer.wait_closed()
+
+            if logger:
+                logger.info(f"Broker at {host}:{port} is reachable.")
+            return True
+
+        except (OSError, ConnectionRefusedError):
+            attempt += 1
+            msg: str = f"Broker at {host}:{port} not reachable. Attempt {attempt}"
+            if logger:
+                logger.warn(msg)
+            else:
+                print(msg)
+
+            if max_attempts and attempt >= max_attempts:
+                if logger:
+                    logger.error(
+                        f"Broker not reachable after {max_attempts} attempts.")
+                return False
+
+        await asyncio.sleep(delay)
+
+    return False

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/mqtt_publisher.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/mqtt_publisher.py
@@ -1,81 +1,10 @@
 import asyncio
 import json
 from typing import Any, Optional
-import paho.mqtt.client as mqtt
 import rclpy
 from rclpy.impl.rcutils_logger import RcutilsLogger
 
 from gmqtt import Client
-
-
-class MQTT:
-    __slots__: tuple[str, ...] = (
-        '__token',
-        '__client',
-        '__topic',
-        '__host',
-        '__port',
-        '__log'
-    )
-
-    def __init__(self, token: str, log: RcutilsLogger, host: str, port: int = 1883) -> None:
-        self.__token: str = token
-        self.__host: str = host
-        self.__port: int = port
-        self.__log: RcutilsLogger = log
-
-        self.__topic: str = "v1/devices/me/telemetry"
-
-        # Initialize MQTT client
-        self.__client = mqtt.Client()
-        self.__client.username_pw_set(self.__token)
-
-        # Bind callbacks
-        self.__client.on_connect = self._on_connect
-        self.__client.on_disconnect = self._on_disconnect
-
-    @property
-    def client(self) -> mqtt.Client:
-        return self.__client
-
-    def connect(self) -> None:
-        try:
-            self.__log.info('Trying to connect to ThingsBoard...')
-            self.__client.connect(self.__host, self.__port, keepalive=60)
-            self.__client.loop_start()
-        except Exception as e:
-            self.__log.error(f'Failed to connect: {e}')
-
-    def disconnect(self) -> None:
-        self.__client.loop_stop()
-        self.__client.disconnect()
-        self.__log.info('Disconnected from ThingsBoard')
-
-    def publish_data(self, data: dict[str, Any]) -> None:
-        msg: str = json.dumps(data)
-        self.__log.info(
-            f'Publishing data [topic: {self.__topic}, {self.__host}:{self.__port}]')
-        self.__client.publish(
-            topic=self.__topic,
-            payload=msg.encode(),
-            qos=1
-        )
-
-    def _on_connect(self, client, userdata, flags, rc) -> None:
-        if rc == 0:
-            self.__log.info('Successfully connected to ThingsBoard.')
-        else:
-            self.__log.error(f'Connection failed with return code {rc}')
-
-    def _on_disconnect(self, client, userdata, rc) -> None:
-        self.__log.error(f'Disconnected with result code {rc}')
-        # If unexpected disconnect (rc != 0), try auto reconnect
-        if rc != 0:
-            self.__log.info('Attempting to reconnect...')
-            try:
-                client.reconnect()
-            except Exception as e:
-                self.__log.error(f'Auto-reconnect failed: {e}')
 
 
 class MQTTClient:
@@ -122,7 +51,7 @@ class MQTTClient:
 
             await self._client.connect(
                 self._host, self._port,
-                keepalive=60
+                keepalive=10
             )
 
             await self._connected.wait()
@@ -143,7 +72,12 @@ class MQTTClient:
         msg: str = json.dumps(data)
 
         if not self._connected.is_set():
-            raise RuntimeError("Client not initialized. Use 'connect'.")
+            self._log.warn("Client not initialized. Use 'connect'.")
+            return
+
+        if not self._client.is_connected:
+            self._log.warn("Client is disconnected.")
+            return
 
         self._log.info(
             f'Publishing data [topic: {self._topic}, {self._host}:{self._port}]')

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
@@ -98,10 +98,19 @@ class F170(Node):
 def main(args=None):
     rclpy.init(args=args)
     node = F170()
+
     try:
         rclpy.spin(node)
+    except KeyboardInterrupt:
+        node.get_logger().info("KeyboardInterrupt received. Exiting gracefully...")
     except Exception as e:
-        node.get_logger().error(f"An Exception: {e} has occurred.")
+        node.get_logger().error(f"Unexpected exception: {e}")
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+
+        # Only shut down if still running
+        if rclpy.ok():
+            try:
+                rclpy.shutdown()
+            except Exception as e:
+                node.get_logger().warn(f"Ignoring shutdown error: {e}")

--- a/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
+++ b/ros_workspace/src/stratasys_f170/stratasys_f170/printer.py
@@ -1,14 +1,19 @@
+import asyncio
 import json
+from threading import Thread
 from typing import Any
+
+from httpx import Response
+
 import rclpy
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.node import Node
 from rclpy.publisher import Publisher
-from rclpy.timer import Timer
 from std_msgs.msg import String
-from stratasys_f170.device import get_device_status
+
+from stratasys_f170.device import DeviceRequest, wait_for_device_ip
 from stratasys_f170.xml_parser import parse_data
-from stratasys_f170.mqtt_publisher import MQTT
+from stratasys_f170.mqtt_publisher import MQTTClient, wait_for_broker
 
 
 class F170(Node):
@@ -30,37 +35,64 @@ class F170(Node):
         self.publisher_: Publisher = self.create_publisher(
             String, 'status', 10)
 
-        self.iot = MQTT(
-            token=self.access_token,
-            log=self.get_logger(),
-            host=self.tb_host,
-            port=self.tb_port
-        )
-
         self.get_logger().info(f'TB: {self.tb_host}:{self.tb_port}')
         self.get_logger().info(f'F170 IP: {self.device_ip}')
 
-        self.iot.connect()
+        _log: RcutilsLogger = self.get_logger()
 
-        self.timer: Timer = self.create_timer(0.005, self.publish_callback)
+        self.request = DeviceRequest(url=self.device_ip, log=_log)
+        self.iot = MQTTClient(
+            token=self.access_token, log=_log,
+            host=self.tb_host, port=self.tb_port
+        )
 
-    def publish_callback(self) -> None:
-        parsed_data: None | dict[str, Any] = self.get_device_data()
-        if parsed_data is None:
-            self.get_logger().warning('No data received from f170 device')
-            return
+        self.loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+        self.thread = Thread(target=self.start_loop, daemon=True)
+        self.thread.start()
+        asyncio.run_coroutine_threadsafe(self.publish_data(), self.loop)
 
-        self.get_logger().debug(f'Received {parsed_data}')
+    def start_loop(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
 
-        self.msg = String()
-        self.msg.data = json.dumps(parsed_data)
+    async def publish_data(self) -> None:
+        _log: RcutilsLogger = self.get_logger()
 
-        self.iot.publish_data(data=parsed_data)
-        self.publisher_.publish(self.msg)
+        await wait_for_device_ip(ip=self.device_ip, delay=5, logger=_log)
+        await wait_for_broker(host=self.tb_host, delay=5, logger=_log)
 
-    def get_device_data(self) -> None | dict[str, Any]:
-        xml_data: str = get_device_status(ip=self.device_ip)
-        return parse_data(xml_data=xml_data)
+        await self.request.connect()
+        await self.iot.connect()
+
+        try:
+            while rclpy.ok():
+                try:
+                    response: Response = await self.request.get()
+
+                except Exception as e:
+                    self.get_logger().error(f"HTTP fetch failed: {e}")
+                    # await wait_for_device_ip(ip=self.device_ip, delay=5, logger=self.get_logger())
+                    continue
+
+                parsed_data: None | dict[str, Any] = parse_data(
+                    xml_data=response.text)
+                if parsed_data is None:
+                    self.get_logger().warning('No data received from f170 device')
+                    return
+
+                self.msg = String()
+                self.msg.data = json.dumps(parsed_data)
+
+                await self.iot.publish_data(data=parsed_data)
+                self.publisher_.publish(self.msg)
+        finally:
+            await self.request.disconnect()
+
+    def destroy_node(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join()
+
+        super().destroy_node()
 
 
 def main(args=None):


### PR DESCRIPTION
Updated with sync and basic error handling

## Summary by Sourcery

Migrate MQTT publishing and device HTTP requests to asyncio, implement basic error handling and retry logic, and refactor the ROS node to operate the async loop in a dedicated thread

Enhancements:
- Replace synchronous paho-mqtt client with an asyncio-based gmqtt MQTTClient featuring async connect/disconnect and publish methods with connection state handling
- Introduce DeviceRequest class using HTTPX AsyncClient and add ping_ip and wait_for_device_ip functions for asynchronous device reachability checks
- Refactor F170 ROS node to run the asynchronous data fetch and publish loop in a background thread, incorporating broker and device readiness waits and improved error handling

Build:
- Update Dockerfile to install httpx and gmqtt instead of requests and paho-mqtt